### PR TITLE
Remove "brew tap" step from "Requirements" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 ## Requirements
 
 - [Homebrew][] in an acceptably recent macOS
-- tap this repo into your Homebrew installation (one-time operation):
-```sh
-$ brew tap pharo-project/pharo
-```
 
 ## Usage
 


### PR DESCRIPTION
It is no longer needed, brew cask does that automatically